### PR TITLE
fix deprecated instance variables in header

### DIFF
--- a/Sources/CocoaLumberjack/DDAbstractDatabaseLogger.m
+++ b/Sources/CocoaLumberjack/DDAbstractDatabaseLogger.m
@@ -28,11 +28,26 @@
 - (void)updateDeleteTimer;
 - (void)createAndStartDeleteTimer;
 
+
+@property (readwrite, assign) NSInteger saveTimerSuspended;
+@property (readwrite, assign) NSUInteger unsavedCount;
+@property (readwrite, assign) dispatch_time_t unsavedTime;
+@property (readwrite, strong) dispatch_source_t saveTimer;
+@property (readwrite, assign) dispatch_time_t lastDeleteTime;
+@property (readwrite, strong) dispatch_source_t deleteTimer;
+
+
 @end
 
 #pragma mark -
 
 @implementation DDAbstractDatabaseLogger
+
+@synthesize saveInterval = _saveInterval;
+@synthesize saveThreshold = _saveThreshold;
+@synthesize maxAge = _maxAge;
+@synthesize deleteInterval = _deleteInterval;
+@synthesize deleteOnEverySave = _deleteOnEverySave;
 
 - (instancetype)init {
     if ((self = [super init])) {

--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDAbstractDatabaseLogger.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDAbstractDatabaseLogger.h
@@ -29,22 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
  * All that is needed for a concrete database logger is to extend this class
  * and override the methods in the implementation file that are prefixed with "db_".
  **/
-@interface DDAbstractDatabaseLogger : DDAbstractLogger {
-    
-@protected
-    NSUInteger _saveThreshold;
-    NSTimeInterval _saveInterval;
-    NSTimeInterval _maxAge;
-    NSTimeInterval _deleteInterval;
-    BOOL _deleteOnEverySave;
-    
-    NSInteger _saveTimerSuspended;
-    NSUInteger _unsavedCount;
-    dispatch_time_t _unsavedTime;
-    dispatch_source_t _saveTimer;
-    dispatch_time_t _lastDeleteTime;
-    dispatch_source_t _deleteTimer;
-}
+@interface DDAbstractDatabaseLogger : DDAbstractLogger
 
 /**
  * Specifies how often to save the data to disk.

--- a/Tests/CocoaLumberjackTests/DDBasicLoggingTests.m
+++ b/Tests/CocoaLumberjackTests/DDBasicLoggingTests.m
@@ -226,6 +226,14 @@ static int const DDLoggerCount = 3;
 
 @end
 
+@interface DDTestDatabaseLogger ()
+
+@property (readwrite, assign) NSInteger saveTimerSuspended;
+@property (readwrite, assign) dispatch_time_t unsavedTime;
+@property (readwrite, strong) dispatch_source_t saveTimer;
+
+@end
+
 @implementation DDTestDatabaseLogger
 
 - (void)setUnsavedTime


### PR DESCRIPTION
### New Pull Request Checklist

- [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
- [ ] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
- [ ] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

<br/>

- [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necessary)
- [ ] I have run the tests and they pass
- [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

...
